### PR TITLE
Allow mixing of Katakana and Hiragana

### DIFF
--- a/src/lib/statuses.ts
+++ b/src/lib/statuses.ts
@@ -54,6 +54,17 @@ export const getStatuses = (
     isHintMode = loaded.isHintMode
   }
 
+  return getStatusesPure(guesses, solution, isHintMode)
+}
+
+export const getStatusesPure = (
+  guesses: string[],
+  solution: string,
+  isHintMode: boolean
+): { [key: string]: CharStatus } => {
+  const charObj: { [key: string]: CharStatus } = {}
+  const splitSolution = unicodeSplit(solution)
+
   function updateCharObjectKey(letter: string, value: CharStatus) {
     // Sets a new status of a key, only if the new status is more important than a previous status
     // i.e. 'present' does not override 'correct', if the character appears twice
@@ -107,20 +118,27 @@ export const getGuessStatuses = (
   guess: string,
   solution: string
 ): CharStatus[] => {
+  let isHintMode = getStoredIsHintMode()
+  const loaded = loadShareStatusFromLocalStorage()
+
+  if (loaded) {
+    isHintMode = loaded.isHintMode
+  }
+
+  return getGuessStatusesPure(guess, solution, isHintMode)
+}
+
+export const getGuessStatusesPure = (
+  guess: string,
+  solution: string,
+  isHintMode: boolean
+): CharStatus[] => {
   const splitSolution = unicodeSplit(solution)
   const splitGuess = unicodeSplit(guess)
 
   const solutionCharsTaken = splitSolution.map((_) => false)
 
   const statuses: CharStatus[] = Array.from(Array(guess.length))
-
-  let isHintMode = getStoredIsHintMode()
-
-  const loaded = loadShareStatusFromLocalStorage()
-
-  if (loaded) {
-    isHintMode = loaded.isHintMode
-  }
 
   // handle all correct cases first
   splitGuess.forEach((letter, i) => {

--- a/src/lib/statuses.ts
+++ b/src/lib/statuses.ts
@@ -44,10 +44,7 @@ export const getStatuses = (
   guesses: string[],
   solution: string
 ): { [key: string]: CharStatus } => {
-  const charObj: { [key: string]: CharStatus } = {}
-  const splitSolution = unicodeSplit(solution)
   let isHintMode = getStoredIsHintMode()
-
   const loaded = loadShareStatusFromLocalStorage()
 
   if (loaded) {
@@ -79,33 +76,33 @@ export const getStatusesPure = (
     unicodeSplit(word).forEach((letter, i) => {
       if (isHintMode) {
         vowelStatusKana.forEach((kana) => {
-          if (kana.includes(letter) && kana.includes(splitSolution[i])) {
+          if (includesMixedKana(kana, letter) && includesMixedKana(kana, splitSolution[i])) {
             updateCharObjectKey(letter, 'vowel')
           }
         })
 
         consonantStatusKana.forEach((kana) => {
-          if (kana.includes(letter) && kana.includes(splitSolution[i])) {
+          if (includesMixedKana(kana, letter) && includesMixedKana(kana, splitSolution[i])) {
             updateCharObjectKey(letter, 'consonant')
           }
         })
 
         closeStatusKana.forEach((kana) => {
-          if (kana.includes(letter) && kana.includes(splitSolution[i])) {
+          if (includesMixedKana(kana, letter) && includesMixedKana(kana, splitSolution[i])) {
             updateCharObjectKey(letter, 'close')
           }
         })
       }
 
-      if (!splitSolution.includes(letter)) {
+      if (!splitSolution.some((solLetter) => includesMixedKana(solLetter, letter))) {
         updateCharObjectKey(letter, 'absent')
       }
 
-      if (splitSolution.includes(letter)) {
+      if (splitSolution.some((solLetter) => includesMixedKana(solLetter, letter))) {
         updateCharObjectKey(letter, 'present')
       }
 
-      if (letter === splitSolution[i]) {
+      if (includesMixedKana(letter, splitSolution[i])) {
         updateCharObjectKey(letter, 'correct')
       }
     })
@@ -142,7 +139,7 @@ export const getGuessStatusesPure = (
 
   // handle all correct cases first
   splitGuess.forEach((letter, i) => {
-    if (letter === splitSolution[i]) {
+    if (includesMixedKana(letter, splitSolution[i])) {
       statuses[i] = 'correct'
       solutionCharsTaken[i] = true
       return
@@ -154,7 +151,7 @@ export const getGuessStatusesPure = (
 
     if (isHintMode) {
       closeStatusKana.forEach((kana) => {
-        if (kana.includes(letter) && kana.includes(splitSolution[i])) {
+        if (includesMixedKana(kana, letter) && includesMixedKana(kana, splitSolution[i])) {
           // handles status close
           statuses[i] = 'close'
           return
@@ -166,7 +163,7 @@ export const getGuessStatusesPure = (
 
     // now we are left with "present"s
     const indexOfPresentChar = splitSolution.findIndex(
-      (x, index) => x === letter && !solutionCharsTaken[index]
+      (x, index) => includesMixedKana(x, letter) && !solutionCharsTaken[index]
     )
 
     if (indexOfPresentChar > -1) {
@@ -179,7 +176,7 @@ export const getGuessStatusesPure = (
 
     if (isHintMode) {
       consonantStatusKana.forEach((kana) => {
-        if (kana.includes(letter) && kana.includes(splitSolution[i])) {
+        if (includesMixedKana(kana, letter) && includesMixedKana(kana, splitSolution[i])) {
           // handles status consonant
           statuses[i] = 'consonant'
           return
@@ -191,7 +188,7 @@ export const getGuessStatusesPure = (
 
     if (isHintMode) {
       vowelStatusKana.forEach((kana) => {
-        if (kana.includes(letter) && kana.includes(splitSolution[i])) {
+        if (includesMixedKana(kana, letter) && includesMixedKana(kana, splitSolution[i])) {
           // handles status vowel
           statuses[i] = 'vowel'
           return
@@ -217,4 +214,8 @@ export const getGuessStatusesPure = (
   })
 
   return statuses
+}
+
+const includesMixedKana = (kana1: string, kana2: string) => {
+  return toHiragana(kana1).includes(toHiragana(kana2))
 }

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -23,7 +23,7 @@ export const isWordInWordList = (word: string) => {
 }
 
 export const isWinningWord = (word: string) => {
-  return solution === word
+  return toHiragana(solution) === toHiragana(word)
 }
 
 // build a set of previously revealed letters - present and correct

--- a/src/statuses.test.tsx
+++ b/src/statuses.test.tsx
@@ -149,3 +149,12 @@ describe('getGuessStatusPure with hint mode', () => {
     expect(resultNoHint).toStrictEqual(expectedStatusNoHint)
   })
 })
+
+describe('Mixed kana support', () => {
+  test('Hiragana solution, Katakana guess', () => {
+    const solution = 'ローマじ'
+    const guesses = 'ろーまじ'
+    const expectedStatus = ['correct', 'correct', 'correct', 'correct']
+    expect(getGuessStatuses(guesses, solution)).toStrictEqual(expectedStatus)
+  })
+})

--- a/src/statuses.test.tsx
+++ b/src/statuses.test.tsx
@@ -1,4 +1,10 @@
-import { getGuessStatuses, getStatuses } from './lib/statuses'
+import exp from 'constants'
+import {
+  getGuessStatuses,
+  getGuessStatusesPure,
+  getStatuses,
+  getStatusesPure,
+} from './lib/statuses'
 
 describe('Maps statuses correctly', () => {
   test('All correct', () => {
@@ -43,5 +49,103 @@ describe('Maps keyboard statuses correctly', () => {
 
     expect(result['い']).toStrictEqual('correct')
     expect(result['て']).toStrictEqual('vowel')
+  })
+})
+
+describe('getStatusesPure with hint mode', () => {
+  test('consonant hint', () => {
+    const solution = 'かんじん'
+    const guesses = ['けんじん', 'かんてん']
+    const result = getStatusesPure(guesses, solution, true)
+    expect(result['か']).toStrictEqual('correct')
+    expect(result['け']).toStrictEqual('consonant')
+    expect(result['ん']).toStrictEqual('correct')
+    expect(result['じ']).toStrictEqual('correct')
+    expect(result['て']).toStrictEqual('absent')
+
+    // without hint
+    const resultNoHint = getStatusesPure(guesses, solution, false)
+    expect(resultNoHint['か']).toStrictEqual('correct')
+    expect(resultNoHint['け']).toStrictEqual('absent')
+    expect(resultNoHint['ん']).toStrictEqual('correct')
+    expect(resultNoHint['じ']).toStrictEqual('correct')
+    expect(resultNoHint['て']).toStrictEqual('absent')
+  })
+
+  test('vowel hint', () => {
+    const solution = 'ていしき'
+    const guesses = ['けいしき', 'かんしき']
+    const result = getStatusesPure(guesses, solution, true)
+    expect(result['け']).toStrictEqual('vowel')
+    expect(result['い']).toStrictEqual('correct')
+    expect(result['し']).toStrictEqual('correct')
+    expect(result['か']).toStrictEqual('absent')
+    expect(result['ん']).toStrictEqual('absent')
+
+    // without hint
+    const resultNoHint = getStatusesPure(guesses, solution, false)
+    expect(resultNoHint['け']).toStrictEqual('absent')
+    expect(resultNoHint['い']).toStrictEqual('correct')
+    expect(resultNoHint['し']).toStrictEqual('correct')
+    expect(resultNoHint['か']).toStrictEqual('absent')
+    expect(resultNoHint['ん']).toStrictEqual('absent')
+  })
+
+  test('close hint', () => {
+    const solution = 'かんしん'
+    const guesses = ['かんじん', 'かんてん']
+    const result = getStatusesPure(guesses, solution, true)
+    expect(result['か']).toStrictEqual('correct')
+    expect(result['ん']).toStrictEqual('correct')
+    expect(result['じ']).toStrictEqual('close')
+    expect(result['て']).toStrictEqual('absent')
+
+    // without hint
+    const resultNoHint = getStatusesPure(guesses, solution, false)
+    expect(resultNoHint['か']).toStrictEqual('correct')
+    expect(resultNoHint['ん']).toStrictEqual('correct')
+    expect(resultNoHint['じ']).toStrictEqual('absent')
+    expect(resultNoHint['て']).toStrictEqual('absent')
+  })
+})
+
+describe('getGuessStatusPure with hint mode', () => {
+  test('consonant hint', () => {
+    const solution = 'かんじん'
+    const guesses = 'けんじん'
+    const expectedStatus = ['consonant', 'correct', 'correct', 'correct']
+    const result = getGuessStatusesPure(guesses, solution, true)
+    expect(result).toStrictEqual(expectedStatus)
+
+    // without hint
+    const expectedStatusNoHint = ['absent', 'correct', 'correct', 'correct']
+    const resultNoHint = getGuessStatusesPure(guesses, solution, false)
+    expect(resultNoHint).toStrictEqual(expectedStatusNoHint)
+  })
+
+  test('vowel hint', () => {
+    const solution = 'ていしき'
+    const guesses = 'けいしき'
+    const expectedStatus = ['vowel', 'correct', 'correct', 'correct']
+    const result = getGuessStatusesPure(guesses, solution, true)
+    expect(result).toStrictEqual(expectedStatus)
+
+    // without hint
+    const expectedStatusNoHint = ['absent', 'correct', 'correct', 'correct']
+    const resultNoHint = getGuessStatusesPure(guesses, solution, false)
+    expect(resultNoHint).toStrictEqual(expectedStatusNoHint)
+  })
+
+  test('close hint', () => {
+    const solution = 'かんしん'
+    const guesses = 'かんじん'
+    const expectedStatus = ['correct', 'correct', 'close', 'correct']
+    const result = getGuessStatusesPure(guesses, solution, true)
+    expect(result).toStrictEqual(expectedStatus)
+
+    // without hint
+    const expectedStatusNoHint = ['correct', 'correct', 'absent', 'correct']
+    const resultNoHint = getGuessStatusesPure(guesses, solution, false)
+    expect(resultNoHint).toStrictEqual(expectedStatusNoHint)
   })
 })


### PR DESCRIPTION
Allow mixing of Katakana and Hiragana
    
Currently, the implementation does not handle mixing Katakana and Hiragana well, as described in https://github.com/taximanli/kotobade-asobou/issues/58

For example, answering "ろーまじ" for "ローマじ" is not considered correct.
This change allows mixing of Katakana and Hiragana.

I also added some tests and refactored the code a bit to improve readability and maintainability.

<img width="496" height="828" alt="Untitled" src="https://github.com/user-attachments/assets/5c05a80a-546b-4bf6-bdf7-ec8f250a1bff" />

